### PR TITLE
FIX: Unexpected duplicate selector ".clearfix:before,
.clearfix:after", first used at line 2 (no-duplicate-selectors)

### DIFF
--- a/js-experiments/SModus/css/reset.css
+++ b/js-experiments/SModus/css/reset.css
@@ -4,10 +4,6 @@
   content: "";
   display: table;
 }
-.clearfix:before,
-.clearfix:after {
-  clear: both;
-}
 .clearfix {
   zoom: 1; /* For IE 6/7 (trigger hasLayout) */
 }


### PR DESCRIPTION
Fix for Unexpected duplicate selector ".clearfix:before,
.clearfix:after", first used at line 2 (no-duplicate-selectors)